### PR TITLE
Deal with dependency artifacts that have classifiers.

### DIFF
--- a/src/main/java/org/terracotta/forge/plugin/ManifestMojo.java
+++ b/src/main/java/org/terracotta/forge/plugin/ManifestMojo.java
@@ -107,7 +107,11 @@ public class ManifestMojo extends AbstractMojo {
             classpath.append(file.getName()).append(" ");
 
             mavenStyleClassPath.append(a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getBaseVersion() + ":"
-                                           + a.getType()).append(" ");
+                + a.getType());
+            if (a.hasClassifier()) {
+              mavenStyleClassPath.append(":" + a.getClassifier());
+            }
+            mavenStyleClassPath.append(" ");
           }
         }
       }

--- a/src/main/java/org/terracotta/forge/plugin/SetL2ClasspathMojo.java
+++ b/src/main/java/org/terracotta/forge/plugin/SetL2ClasspathMojo.java
@@ -4,6 +4,7 @@
 package org.terracotta.forge.plugin;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.filter.CumulativeScopeArtifactFilter;
@@ -115,10 +116,11 @@ public class SetL2ClasspathMojo extends AbstractMojo {
         nodes.remove(rootNode);
         Set<Artifact> terracottaDirectAndTransitiveDependencies =  new TreeSet<Artifact>();
         for (DependencyNode node : nodes) {
-          Artifact nodeArtifact = node.getArtifact();
-          Artifact completeArtifact = defaultArtifactFactory.createArtifact(nodeArtifact.getGroupId(), nodeArtifact.getArtifactId(), nodeArtifact.getVersion(), nodeArtifact.getScope(), nodeArtifact.getType());
-          completeArtifact.setFile(new File(localRepository.getBasedir(), localRepository.pathOf(completeArtifact)));
-          terracottaDirectAndTransitiveDependencies.add(completeArtifact);
+          Artifact completeArtifact = ArtifactUtils.copyArtifactSafe(node.getArtifact());
+          if (completeArtifact != null) {
+            completeArtifact.setFile(new File(localRepository.getBasedir(), localRepository.pathOf(completeArtifact)));
+            terracottaDirectAndTransitiveDependencies.add(completeArtifact);
+          }
         }
         //we end up with the list of artifacts under the root node
 


### PR DESCRIPTION
If you build main/4.4.1/4.4.0 with a clean local Maven repo, the test servers will get an incorrect classpath from this plugin because we've started using artifacts with classifiers, such as Shiro and Jetty. This PR fixes that.